### PR TITLE
Add optional word delimiter argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # split-string-words
 Splits a string into individual words, taking quotes into account
 
-## Install 
+## Install
 ```
 $ npm install --save split-string-words
 ```
@@ -12,11 +12,20 @@ $ npm install --save split-string-words
 
 var split = require('split-string-words');
 
-split('hello this is dog'); 
+split('hello this is dog');
 //=> ["hello", "this", "is", "dog"]
 
-split('hello "this is dog"'); 
+split('hello "this is dog"');
 //=> ["hello", "this is dog"]
+
+split('filename hello-world.js');
+//=> ["filename", "hello", "world", "js"]
+
+// You can also provide an optional regex delimiter, which can be used in place of `\w`.
+// Keep in mind that you must escape backslashes.
+
+split('filename hello-world.js', '[^\\s]');
+//=> ["filename", "hello-world.js"]
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
-module.exports = function(string) {
-    return string.match(/\w+|"(?:\\"|[^"])+"/g)
-        .map(function(word) { return word.replace(/^\"|\"$/g, ""); });  // Remove quotes from start and end of quoted strings matched above
+module.exports = function(string, delimiter) {
+    var wordDelimiter = delimiter || "\\w";
+    var word = new RegExp('"(?:\\"|[^"])+"|' + wordDelimiter + '+', "g");
+    var outerQuote = /^\"|\"$/g;
+    return string.match(word)
+        .map(function(word) {
+            // Remove quotes from start and end of quoted strings matched above
+            return word.replace(outerQuote, "");
+        });
 };

--- a/test.js
+++ b/test.js
@@ -3,8 +3,17 @@
 var split = require("./index");
 var test = require('tap').test;
 
-test('Test', function (t) {
+test('Default behavior', function (t) {
     t.deepEqual(split('hello this is dog'), ["hello", "this", "is", "dog"]);
     t.deepEqual(split('hello "this is dog"'), ["hello", "this is dog"]);
+    t.deepEqual(split('hello.world "this is dog"'), ["hello", "world", "this is dog"]);
+    t.end();
+});
+
+test('Custom delimiter', function (t) {
+    var delimiter = "[^\\s]";
+    t.deepEqual(split('filename hello-world.js', delimiter), ["filename", "hello-world.js"]);
+    t.deepEqual(split('filename hello-world.js', delimiter), ["filename", "hello-world.js"]);
+    t.deepEqual(split('hello.world "this is dog"', delimiter), ["hello.world", "this is dog"]);
     t.end();
 });


### PR DESCRIPTION
Not sure if you're interested in this PR, but I had the need for delimiting words strictly on spaces, instead of on non-word characters.

I included extra tests for the previous functionality, and new tests for the new functionality, as well as documentation.

I also bumped the minor version, since this is an API change, but is backwards compatible.