### PR TITLE
Split on spaces, not all non-word characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ split('hello this is dog');
 
 split('hello "this is dog"'); 
 //=> ["hello", "this is dog"]
+
+split('filename hello-world.js');
+//=> ["filename", "hello-world.js"]
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 module.exports = function(string) {
-    return string.match(/\w+|"(?:\\"|[^"])+"/g)
+    return string.match(/"(?:\\"|[^"])+"|[^\s]+/g)
         .map(function(word) { return word.replace(/^\"|\"$/g, ""); });  // Remove quotes from start and end of quoted strings matched above
 };

--- a/test.js
+++ b/test.js
@@ -6,5 +6,6 @@ var test = require('tap').test;
 test('Test', function (t) {
     t.deepEqual(split('hello this is dog'), ["hello", "this", "is", "dog"]);
     t.deepEqual(split('hello "this is dog"'), ["hello", "this is dog"]);
+    t.deepEqual(split('hello.world "this is dog"'), ["hello.world", "this is dog"]);
     t.end();
 });


### PR DESCRIPTION
The current behavior splits on all non-word characters, which included dots and dashes. Based on the discussion in #1, instead of adding new functionality, this PR changes the previous functionality to more closely match `String.prototype.split()`, while supporting quoted strings.

This PR is much more minimal than #1, but still includes an updated readme and tests.