### PR TITLE
fix: support empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = function(string) {
     if (!string) return [];
-    
-    return string.match(/"(?:\\"|[^"])+"|[^\s]+/g)
+    var match = string.match(/"(?:\\"|[^"])+"|[^\s]+/g);
+    if(!match) return [];
+    return match
         .map(function(word) { return word.replace(/^\"|\"$/g, ""); });  // Remove quotes from start and end of quoted strings matched above
 };

--- a/test.js
+++ b/test.js
@@ -4,7 +4,10 @@ var split = require("./index");
 var test = require('tap').test;
 
 test('Test', function (t) {
-    t.deepEqual(split('hello this is dog'), ["hello", "this", "is", "dog"]);
+    t.deepEqual(split(''), []);
+    t.deepEqual(split(' '), []);
+    t.deepEqual(split('\t'), []);
+    t.deepEqual(split('hello this is dog '), ["hello", "this", "is", "dog"]);
     t.deepEqual(split('hello "this is dog"'), ["hello", "this is dog"]);
     t.deepEqual(split('filenames hello-world.js __winning.py'), ["filenames", "hello-world.js", "__winning.py"]);
     t.deepEqual(split('filenames "hello-world.js __winning.py"'), ["filenames", "hello-world.js __winning.py"]);


### PR DESCRIPTION
Pass empty string and return empty array.

Currently, Pass `""`(empty string) and this library throw error

```
TypeError: Cannot read property 'map' of null
```

Related Issue: https://github.com/azu/textlint-rule-en-max-word-count/issues/3